### PR TITLE
🚀 Feature[KAN-10]: 닉네임 등록 API 추가

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,26 +1,4 @@
 services:
-  backend:
-    restart: always
-    container_name: backend
-    platform: linux/arm64
-    image: asia-northeast3-docker.pkg.dev/nyang-453314/dev-nyang-backend/dev/api:0.155
-    environment:
-      JAVA_TOOL_OPTIONS: -Dspring.profiles.active=dev
-      OAUTH-KAKAO-CLIENT-ID: 673eb79b7224ec2e608d5d18970ffaea
-      OAUTH-KAKAO-CLIENT-SECRET: 5Bqx3nC3mN3jn0rBFvxDxZhzYVoqBz3t
-      OAUTH-GOOGLE-CLIENT-ID: 404158275662-8b5h0crn3ldiu9v8r850soli5mdmiss4.apps.googleusercontent.com
-      OAUTH-GOOGLE-CLIENT-SECRET: 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
-      JWT-SECRET: nyangnyangminshik
-      MONGO_INITDB_DATABASE: mydatabase
-      MONGO_INITDB_ROOT_PASSWORD: secret
-      MONGO_INITDB_ROOT_USERNAME: root
-    depends_on:
-      - mongodb
-      - redis
-    ports:
-      - '9000:8080'
-    networks:
-      - dev-puzzle-net
   mongodb:
     container_name: mongodb
     image: 'mongo:latest'

--- a/src/main/java/nyang/puzzlebackend/api/NicknameController.java
+++ b/src/main/java/nyang/puzzlebackend/api/NicknameController.java
@@ -5,7 +5,10 @@ import nyang.puzzlebackend.api.common.ApiResponse;
 import nyang.puzzlebackend.api.request.NicknameRequest;
 import nyang.puzzlebackend.api.request.validation.NicknameValidationSequence;
 import nyang.puzzlebackend.api.response.user.NicknameAvailableResponse;
+import nyang.puzzlebackend.auth.AppUser;
+import nyang.puzzlebackend.auth.AuthPrincipal;
 import nyang.puzzlebackend.domain.user.NicknameService;
+import nyang.puzzlebackend.domain.user.UserInfoService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class NicknameController {
 
   private final NicknameService nicknameService;
+  private final UserInfoService userInfoService;
 
   @PostMapping("/user/nickname/available-check")
   public ApiResponse<NicknameAvailableResponse> checkNicknameDuplicated(
@@ -23,5 +27,15 @@ public class NicknameController {
   ) {
     boolean isAvailable = nicknameService.checkAvailableNickname(nicknameRequest.nickname());
     return ApiResponse.ok(new NicknameAvailableResponse(isAvailable));
+  }
+
+  @PostMapping("/user/nickname")
+  public ApiResponse<?> register(
+      @Validated(value = NicknameValidationSequence.class)
+      @RequestBody NicknameRequest nicknameRequest,
+      @AuthPrincipal AppUser appUser
+  ) {
+    userInfoService.updateNickname(nicknameRequest.nickname(), appUser);
+    return ApiResponse.ok();
   }
 }

--- a/src/main/java/nyang/puzzlebackend/api/common/ApiResponse.java
+++ b/src/main/java/nyang/puzzlebackend/api/common/ApiResponse.java
@@ -2,13 +2,10 @@ package nyang.puzzlebackend.api.common;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.time.Instant;
 import nyang.puzzlebackend.global.error.ErrorContent;
 import nyang.puzzlebackend.global.error.ErrorContents;
 
-@JsonInclude(value = Include.NON_NULL)
 public record ApiResponse<T>(
     String result,
     T data,
@@ -31,6 +28,10 @@ public record ApiResponse<T>(
 
   public static <T> ApiResponse<T> ok(T data) {
     return new ApiResponse<>("success", data);
+  }
+
+  public static <T> ApiResponse<T> ok() {
+    return new ApiResponse<>("success", null, ISO_INSTANT.format(Instant.now()), null, null);
   }
 
   public static <T> ApiResponse<T> error(ErrorContent errorContent) {

--- a/src/main/java/nyang/puzzlebackend/auth/AppUser.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AppUser.java
@@ -1,0 +1,3 @@
+package nyang.puzzlebackend.auth;
+
+public record AppUser(String uid) { }

--- a/src/main/java/nyang/puzzlebackend/auth/AuthPrincipal.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AuthPrincipal.java
@@ -1,0 +1,10 @@
+package nyang.puzzlebackend.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = {ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthPrincipal { }

--- a/src/main/java/nyang/puzzlebackend/auth/AuthPrincipalArgumentResolver.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AuthPrincipalArgumentResolver.java
@@ -1,0 +1,38 @@
+package nyang.puzzlebackend.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import nyang.puzzlebackend.auth.jwt.JwtTokenProvider;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final JwtTokenProvider tokenProvider;
+  private final AuthenticationService authenticationService;
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getParameterType() == AppUser.class
+        && parameter.hasParameterAnnotation(AuthPrincipal.class);
+  }
+
+  @Override
+  public AppUser resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory
+  ) {
+    var request = webRequest.getNativeRequest(HttpServletRequest.class);
+    var token = tokenProvider.parseTokenFromHeader(request);
+    return authenticationService.findUserByToken(token);
+  }
+
+}

--- a/src/main/java/nyang/puzzlebackend/auth/AuthenticationInterceptor.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AuthenticationInterceptor.java
@@ -1,0 +1,27 @@
+package nyang.puzzlebackend.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final AuthenticationService authenticationService;
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) {
+        if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+            return true;
+        }
+        authenticationService.checkAuthentication(request);
+        return true;
+    }
+}

--- a/src/main/java/nyang/puzzlebackend/auth/AuthenticationService.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AuthenticationService.java
@@ -1,7 +1,9 @@
 package nyang.puzzlebackend.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import lombok.extern.slf4j.Slf4j;
 import nyang.puzzlebackend.api.response.AccessRefreshTokenResponse;
 import nyang.puzzlebackend.auth.jwt.AccessRefreshToken;
 import nyang.puzzlebackend.auth.jwt.JwtTokenProvider;
@@ -9,11 +11,14 @@ import nyang.puzzlebackend.auth.oauth.OAuthId;
 import nyang.puzzlebackend.auth.oauth.OAuthProvider;
 import nyang.puzzlebackend.domain.user.User;
 import nyang.puzzlebackend.domain.user.UserRepository;
+import nyang.puzzlebackend.global.error.AuthenticationException;
+import nyang.puzzlebackend.global.error.ErrorCode;
 import org.bson.types.ObjectId;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class AuthenticationService {
 
   private final UserRepository userRepository;
@@ -32,13 +37,13 @@ public class AuthenticationService {
 
   public AccessRefreshTokenResponse generateToken(OAuthId oAuthId, OAuthProvider oAuthProvider) {
     User user = findOAuthUser(oAuthId, oAuthProvider);
-    String accessToken = jwtTokenProvider.issueAccessToken(user.id().toString());
-    String refreshToken = jwtTokenProvider.issueRefreshToken(user.id().toString());
-    saveRefreshToken(user.id(), refreshToken);
-    if (user.nickname() == null) {
+    String accessToken = jwtTokenProvider.issueAccessToken(user.getId().toString());
+    String refreshToken = jwtTokenProvider.issueRefreshToken(user.getId().toString());
+    saveRefreshToken(user.getId(), refreshToken);
+    if (user.getNickname() == null) {
       return AccessRefreshToken.newUser(accessToken, refreshToken);
     }
-    return AccessRefreshToken.of(accessToken, refreshToken, user.nickname());
+    return AccessRefreshToken.of(accessToken, refreshToken, user.getNickname());
   }
 
   private void saveRefreshToken(ObjectId userId, String refreshToken) {
@@ -52,5 +57,17 @@ public class AuthenticationService {
   private User findOAuthUser(OAuthId oAuthId, OAuthProvider provider) {
     return userRepository.findByOauthId(oAuthId.id())
         .orElseGet(() -> userRepository.save(oAuthId.toUserWithProvider(provider)));
+  }
+
+  public AppUser findUserByToken(String token) {
+    return new AppUser(jwtTokenProvider.parseUserId(token));
+  }
+
+  public void checkAuthentication(HttpServletRequest request) {
+    final String token = jwtTokenProvider.parseTokenFromHeader(request);
+    if (!jwtTokenProvider.isValidToken(token)) {
+      log.warn("Invalid JWT token: {}, request: {}", token, request);
+      throw new AuthenticationException(ErrorCode.A002);
+    }
   }
 }

--- a/src/main/java/nyang/puzzlebackend/auth/AuthenticationService.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AuthenticationService.java
@@ -60,6 +60,9 @@ public class AuthenticationService {
   }
 
   public AppUser findUserByToken(String token) {
+    if (!jwtTokenProvider.isValidToken(token)) {
+      throw new AuthenticationException(ErrorCode.A002);
+    }
     return new AppUser(jwtTokenProvider.parseUserId(token));
   }
 

--- a/src/main/java/nyang/puzzlebackend/auth/AuthenticationService.java
+++ b/src/main/java/nyang/puzzlebackend/auth/AuthenticationService.java
@@ -69,7 +69,8 @@ public class AuthenticationService {
   public void checkAuthentication(HttpServletRequest request) {
     final String token = jwtTokenProvider.parseTokenFromHeader(request);
     if (!jwtTokenProvider.isValidToken(token)) {
-      log.warn("Invalid JWT token: {}, request: {}", token, request);
+      log.warn("Invalid JWT token received from IP: {}, URI: {}",
+          request.getRemoteAddr(), request.getRequestURI());
       throw new AuthenticationException(ErrorCode.A002);
     }
   }

--- a/src/main/java/nyang/puzzlebackend/auth/OptionalAuthPrincipal.java
+++ b/src/main/java/nyang/puzzlebackend/auth/OptionalAuthPrincipal.java
@@ -1,0 +1,10 @@
+package nyang.puzzlebackend.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = {ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptionalAuthPrincipal { }

--- a/src/main/java/nyang/puzzlebackend/auth/OptionalAuthPrincipalArgumentResolver.java
+++ b/src/main/java/nyang/puzzlebackend/auth/OptionalAuthPrincipalArgumentResolver.java
@@ -1,0 +1,43 @@
+package nyang.puzzlebackend.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import nyang.puzzlebackend.auth.jwt.JwtTokenProvider;
+import nyang.puzzlebackend.global.error.AuthenticationException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class OptionalAuthPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final JwtTokenProvider tokenProvider;
+  private final AuthenticationService authenticationService;
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getParameterType() == AppUser.class
+        && parameter.hasParameterAnnotation(OptionalAuthPrincipal.class);
+  }
+
+  @Override
+  public Optional<AppUser> resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+    try {
+      var request = webRequest.getNativeRequest(HttpServletRequest.class);
+      var token = tokenProvider.parseTokenFromHeader(request);
+      return Optional.of(authenticationService.findUserByToken(token));
+    } catch (AuthenticationException e) {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/src/main/java/nyang/puzzlebackend/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/nyang/puzzlebackend/auth/jwt/JwtTokenProvider.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
+import nyang.puzzlebackend.global.error.AuthenticationException;
+import nyang.puzzlebackend.global.error.ErrorCode;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -86,7 +88,7 @@ public class JwtTokenProvider {
   public String parseTokenFromHeader(HttpServletRequest httpServletRequest) {
     final String authorization = httpServletRequest.getHeader("Authorization");
     if (Objects.isNull(authorization) || !authorization.startsWith("Bearer")) {
-      throw new IllegalStateException();
+      throw new AuthenticationException(ErrorCode.A001);
     }
     return authorization.substring(7);
   }

--- a/src/main/java/nyang/puzzlebackend/domain/user/User.java
+++ b/src/main/java/nyang/puzzlebackend/domain/user/User.java
@@ -1,7 +1,10 @@
 package nyang.puzzlebackend.domain.user;
 
 import java.time.LocalDateTime;
+import lombok.Getter;
 import nyang.puzzlebackend.auth.oauth.OAuthProvider;
+import nyang.puzzlebackend.global.error.ErrorCode;
+import nyang.puzzlebackend.global.error.PuzzleException;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
@@ -9,21 +12,46 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.Field.Write;
 import org.springframework.data.mongodb.core.mapping.FieldType;
 
+@Getter
 @Document(collection = "users")
-public record User(
-    @Id ObjectId id,
-    @Indexed(unique = true) String oauthId,
-    @Field(targetType = FieldType.STRING) OAuthProvider oAuthProvider,
-    @Indexed(unique = true) String nickname,
-    @CreatedDate LocalDateTime createdAt,
-    @LastModifiedDate LocalDateTime updatedAt,
-    LocalDateTime deletedAt,
-    boolean isDeleted
-) {
+public class User {
+
+  @Id
+  private ObjectId id;
+
+  @Indexed(unique = true)
+  private String oauthId;
+
+  @Field(targetType = FieldType.STRING)
+  private OAuthProvider oAuthProvider;
+
+  @Indexed(unique = true)
+  private String nickname;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  private LocalDateTime deletedAt;
+
+  @Field(write = Write.NON_NULL)
+  private boolean isDeleted;
 
   public User(String oauthId, OAuthProvider oAuthProvider) {
-    this(null, oauthId, oAuthProvider, null, null, null, null, false);
+    this.oauthId = oauthId;
+    this.oAuthProvider = oAuthProvider;
+    this.isDeleted = false;
+  }
+
+  public void initNickname(String nickname) {
+    if (this.nickname != null)
+      throw new PuzzleException(ErrorCode.U005);
+    this.nickname = nickname;
   }
 }
+

--- a/src/main/java/nyang/puzzlebackend/domain/user/UserInfoService.java
+++ b/src/main/java/nyang/puzzlebackend/domain/user/UserInfoService.java
@@ -14,7 +14,7 @@ public class UserInfoService {
 
   private final UserRepository userRepository;
 
-  public void updateNickname(String nickname, AppUser appUser) {
+  public void updateNickname(final String nickname, AppUser appUser) {
     User user = findUser(appUser);
     user.initNickname(nickname);
     userRepository.save(user);

--- a/src/main/java/nyang/puzzlebackend/domain/user/UserInfoService.java
+++ b/src/main/java/nyang/puzzlebackend/domain/user/UserInfoService.java
@@ -1,0 +1,27 @@
+package nyang.puzzlebackend.domain.user;
+
+
+import lombok.RequiredArgsConstructor;
+import nyang.puzzlebackend.auth.AppUser;
+import nyang.puzzlebackend.global.error.ErrorCode;
+import nyang.puzzlebackend.global.error.PuzzleException;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserInfoService {
+
+  private final UserRepository userRepository;
+
+  public void updateNickname(String nickname, AppUser appUser) {
+    User user = findUser(appUser);
+    user.initNickname(nickname);
+    userRepository.save(user);
+  }
+
+  private User findUser(AppUser appUser) {
+    return userRepository.findById(new ObjectId(appUser.uid()))
+        .orElseThrow(() -> new PuzzleException(ErrorCode.U004));
+  }
+}

--- a/src/main/java/nyang/puzzlebackend/domain/user/UserRepository.java
+++ b/src/main/java/nyang/puzzlebackend/domain/user/UserRepository.java
@@ -3,7 +3,13 @@ package nyang.puzzlebackend.domain.user;
 import java.util.Optional;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface UserRepository extends MongoRepository<User, ObjectId> {
+
+  @Override
+  @Query("{ '_id' : ?0, 'isDeleted' : false }")
+  Optional<User> findById(ObjectId id);
+
   Optional<User> findByOauthId(String id);
 }

--- a/src/main/java/nyang/puzzlebackend/global/config/WebConfig.java
+++ b/src/main/java/nyang/puzzlebackend/global/config/WebConfig.java
@@ -3,12 +3,45 @@ package nyang.puzzlebackend.global.config;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import nyang.puzzlebackend.auth.AuthPrincipalArgumentResolver;
+import nyang.puzzlebackend.auth.AuthenticationInterceptor;
+import nyang.puzzlebackend.auth.OptionalAuthPrincipalArgumentResolver;
 import nyang.puzzlebackend.global.logging.LoggingInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig {
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+  private final AuthenticationInterceptor authenticationInterceptor;
+  private final OptionalAuthPrincipalArgumentResolver optionalAuthPrincipalArgumentResolver;
+  private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(authenticationInterceptor)
+        .order(1)
+        .excludePathPatterns(
+            // nickname
+            "/user/nickname/available-check/**",
+
+            // auth
+            "/auth/oauth2/**"
+        );
+
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authPrincipalArgumentResolver);
+    resolvers.add(optionalAuthPrincipalArgumentResolver);
+  }
 
   @Bean
   public ObjectMapper objectMapper() {

--- a/src/main/java/nyang/puzzlebackend/global/error/AuthenticationException.java
+++ b/src/main/java/nyang/puzzlebackend/global/error/AuthenticationException.java
@@ -1,0 +1,8 @@
+package nyang.puzzlebackend.global.error;
+
+public class AuthenticationException extends PuzzleException{
+
+    public AuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/nyang/puzzlebackend/global/error/ErrorCode.java
+++ b/src/main/java/nyang/puzzlebackend/global/error/ErrorCode.java
@@ -7,11 +7,18 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+  // 인증
+  A001("A001", "헤더에 토큰 정보가 없거나 잘못된 양식의 토큰 정보 입니다.", HttpStatus.UNAUTHORIZED),
+  A002("A002", "유효하지 않은 토큰 값입니다. 다시 로그인 바랍니다.", HttpStatus.UNAUTHORIZED),
 
   // 유저 닉네임
-  U001("UN001", "닉네임은 3 ~ 15자 사이 이어야 합니다.", HttpStatus.CONFLICT),
-  U002("UN002", "닉네임에는 공백이 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
-  U003("UN003", "닉네임을 입력하기 바랍니다.", HttpStatus.BAD_REQUEST),
+  U001("U001", "닉네임은 3 ~ 15자 사이 이어야 합니다.", HttpStatus.CONFLICT),
+  U002("U002", "닉네임에는 공백이 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  U003("U002", "닉네임을 입력하기 바랍니다.", HttpStatus.BAD_REQUEST),
+
+  // 유저
+  U004("U004", "존재하지 않거나 이미 탈퇴한 유저입니다.", HttpStatus.FORBIDDEN),
+  U005("U005", "이미 닉네임을 등록하였습니다.", HttpStatus.BAD_REQUEST),
 
   // Uncaught Exception
   X001("X001", "서버에 문제가 발생 하였습니다. 관리자에게 연락해주세요", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/nyang/puzzlebackend/global/error/ErrorCode.java
+++ b/src/main/java/nyang/puzzlebackend/global/error/ErrorCode.java
@@ -14,8 +14,9 @@ public enum ErrorCode {
   // 유저 닉네임
   U001("U001", "닉네임은 3 ~ 15자 사이 이어야 합니다.", HttpStatus.CONFLICT),
   U002("U002", "닉네임에는 공백이 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
-  U003("U002", "닉네임을 입력하기 바랍니다.", HttpStatus.BAD_REQUEST),
-
+  U001("U001", "닉네임은 3 ~ 15자 사이 이어야 합니다.", HttpStatus.CONFLICT),
+  U002("U002", "닉네임에는 공백이 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  U003("U003", "닉네임을 입력하기 바랍니다.", HttpStatus.BAD_REQUEST),
   // 유저
   U004("U004", "존재하지 않거나 이미 탈퇴한 유저입니다.", HttpStatus.FORBIDDEN),
   U005("U005", "이미 닉네임을 등록하였습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
### 티켓 번호

[KAN-10](https://nyangnyang.atlassian.net/browse/KAN-10?atlOrigin=eyJpIjoiNDhhYmVlODlhMjg0NDkyZjhlNTFjYmExZTViYmY4ZmQiLCJwIjoiaiJ9)

### PR 타입(하나 이상을 선택 후 나머지는 지워주세요)

- [x] 기능 추가 (새로운 기능을 추가할 때)
- [ ] 기능 개선 (기존 기능을 수정하거나 개선할 때)
- [ ] 기능 삭제 (기능을 제거할 때)
- [ ] 버그 수정 (오류나 문제를 수정할 때)
- [ ] 성능 개선 (애플리케이션 성능을 향상시킬 때)
- [ ] 코드 리팩토링 (기능 변화 없이 코드 구조를 개선할 때)
- [ ] 테스트 추가/수정 (테스트 케이스를 추가하거나 수정할 때)
- [ ] 문서 업데이트 (문서나 주석을 수정/추가할 때)
- [ ] 의존성, 환경 설정, 빌드 관련 업데이트 (패키지, 설정, 빌드 도구 등을 업데이트할 때)

### 반영 브랜치

- `KAN-10-닉네임-등록` -> `develop`

### 변경 사항

- 공통 인증 처리 기능 추가
    * 인증 처리를 담당하는 `AuthenticationInterceptor.java` 및 인증 객체로 만들어주는 `ArgumentResolver.java` 추가
- 닉네임 등록 API 추가


[KAN-10]: https://nyangnyang.atlassian.net/browse/KAN-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for authenticated users to register a nickname through a new API endpoint.
  - Introduced enhanced authentication handling, allowing endpoints to receive authenticated user information directly.
  - Added support for optional authentication in controller methods.

- **Improvements**
  - Improved error handling and messaging for authentication and user-related actions.
  - Updated user data management to prevent nickname duplication and handle user deletion status.
  - Enhanced API response handling with new utility methods.

- **Chores**
  - Removed the backend service definition from the deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->