### PR TITLE
🚀 Feature[KAN-16]: Add Update User's Profile Image API

### DIFF
--- a/src/main/java/nyang/puzzlebackend/api/UserInfoController.java
+++ b/src/main/java/nyang/puzzlebackend/api/UserInfoController.java
@@ -26,8 +26,7 @@ public class UserInfoController {
     @Valid @RequestBody ImageRequest imageRequest,
     @AuthPrincipal AppUser appUser
   ) {
-    AppUser appUser1 = new AppUser("683c3d8f820a5135a5bf4828");
-    userInfoService.updateProfileImage(imageRequest.imageUrl(), appUser1);
+    userInfoService.updateProfileImage(imageRequest.imageUrl(), appUser);
     return ApiResponse.ok();
   }
 }

--- a/src/main/java/nyang/puzzlebackend/api/UserInfoController.java
+++ b/src/main/java/nyang/puzzlebackend/api/UserInfoController.java
@@ -1,0 +1,33 @@
+package nyang.puzzlebackend.api;
+
+import jakarta.validation.Valid;
+import nyang.puzzlebackend.api.common.ApiResponse;
+import nyang.puzzlebackend.api.request.user.ImageRequest;
+import nyang.puzzlebackend.auth.AppUser;
+import nyang.puzzlebackend.auth.AuthPrincipal;
+import nyang.puzzlebackend.domain.user.UserInfoService;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping
+@RestController
+public class UserInfoController {
+
+  private final UserInfoService userInfoService;
+
+  public UserInfoController(UserInfoService userInfoService) {
+    this.userInfoService = userInfoService;
+  }
+
+  @PatchMapping("/api/user/profile-img")
+  public ApiResponse<?> changeProfileImg(
+    @Valid @RequestBody ImageRequest imageRequest,
+    @AuthPrincipal AppUser appUser
+  ) {
+    AppUser appUser1 = new AppUser("683c3d8f820a5135a5bf4828");
+    userInfoService.updateProfileImage(imageRequest.imageUrl(), appUser1);
+    return ApiResponse.ok();
+  }
+}

--- a/src/main/java/nyang/puzzlebackend/api/request/ImageUrlValidator.java
+++ b/src/main/java/nyang/puzzlebackend/api/request/ImageUrlValidator.java
@@ -1,0 +1,30 @@
+package nyang.puzzlebackend.api.request;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import nyang.puzzlebackend.api.request.validation.ImageUrl;
+
+public class ImageUrlValidator implements ConstraintValidator<ImageUrl, String> {
+
+  private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+  @Override
+  public boolean isValid(String urlString, ConstraintValidatorContext context) {
+    if (urlString == null) {
+      return false;
+    }
+
+    try {
+      URL url = new URL(urlString);
+      String path = url.getPath();
+      String extension = path.substring(path.lastIndexOf(".") + 1).toLowerCase();
+
+      return ALLOWED_EXTENSIONS.contains(extension);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/nyang/puzzlebackend/api/request/user/ImageRequest.java
+++ b/src/main/java/nyang/puzzlebackend/api/request/user/ImageRequest.java
@@ -1,0 +1,10 @@
+package nyang.puzzlebackend.api.request.user;
+
+import jakarta.validation.constraints.NotNull;
+import nyang.puzzlebackend.api.request.validation.ImageUrl;
+
+public record ImageRequest(
+  @NotNull(message = "U006")
+  @ImageUrl(message = "U007")
+  String imageUrl
+) {}

--- a/src/main/java/nyang/puzzlebackend/api/request/validation/ImageUrl.java
+++ b/src/main/java/nyang/puzzlebackend/api/request/validation/ImageUrl.java
@@ -1,0 +1,18 @@
+package nyang.puzzlebackend.api.request.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import nyang.puzzlebackend.api.request.ImageUrlValidator;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ImageUrlValidator.class)
+public @interface ImageUrl {
+    String message() default "Invalid image URL";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/nyang/puzzlebackend/api/request/validation/ImageUrlValidator.java
+++ b/src/main/java/nyang/puzzlebackend/api/request/validation/ImageUrlValidator.java
@@ -1,0 +1,29 @@
+package nyang.puzzlebackend.api.request.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+public class ImageUrlValidator implements ConstraintValidator<ImageUrl, String> {
+
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+    @Override
+    public boolean isValid(String urlString, ConstraintValidatorContext context) {
+        if (urlString == null) {
+            return false;
+        }
+
+        try {
+            URL url = new URL(urlString);
+            String path = url.getPath();
+            String extension = path.substring(path.lastIndexOf(".") + 1).toLowerCase();
+
+            return ALLOWED_EXTENSIONS.contains(extension);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/nyang/puzzlebackend/domain/user/User.java
+++ b/src/main/java/nyang/puzzlebackend/domain/user/User.java
@@ -31,6 +31,9 @@ public class User {
   @Indexed(unique = true)
   private String nickname;
 
+  @Field("profileImage")
+  private String profileImage;
+
   @CreatedDate
   private LocalDateTime createdAt;
 
@@ -53,6 +56,17 @@ public class User {
     if (this.nickname != null)
       throw new PuzzleException(ErrorCode.U005);
     this.nickname = nickname;
+  }
+
+  public void updateProfileImg(String imgUrl) {
+    if (this.profileImage == null) {
+      this.profileImage = imgUrl;
+      return;
+    }
+    if (this.profileImage.equals(imgUrl)) {
+      return;
+    }
+    this.profileImage = imgUrl;
   }
 }
 

--- a/src/main/java/nyang/puzzlebackend/domain/user/UserInfoService.java
+++ b/src/main/java/nyang/puzzlebackend/domain/user/UserInfoService.java
@@ -14,6 +14,12 @@ public class UserInfoService {
 
   private final UserRepository userRepository;
 
+  public void updateProfileImage(final String imgUrl, AppUser appUser) {
+    User user = findUser(appUser);
+    user.updateProfileImg(imgUrl);
+    userRepository.save(user);
+  }
+
   public void updateNickname(final String nickname, AppUser appUser) {
     User user = findUser(appUser);
     user.initNickname(nickname);

--- a/src/main/java/nyang/puzzlebackend/global/error/ErrorCode.java
+++ b/src/main/java/nyang/puzzlebackend/global/error/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
   // 유저
   U004("U004", "존재하지 않거나 이미 탈퇴한 유저입니다.", HttpStatus.FORBIDDEN),
   U005("U005", "이미 닉네임을 등록하였습니다.", HttpStatus.BAD_REQUEST),
+  // 유저 이미지
+  U006("U006", "Image URL must not be null", HttpStatus.BAD_REQUEST),
+  U007("U007", "Invalid image URL format or extension", HttpStatus.BAD_REQUEST),
 
   // 이미지
   I001("I001", "upload 하려는 이미지의 확장자는 필수입니다. (허용: JPG, JPEG, PNG, BMP, WEBP, TIFF, TIF, SVG)", HttpStatus.BAD_REQUEST),

--- a/src/test/java/nyang/puzzlebackend/api/request/ImageUrlValidatorTest.java
+++ b/src/test/java/nyang/puzzlebackend/api/request/ImageUrlValidatorTest.java
@@ -1,0 +1,39 @@
+package nyang.puzzlebackend.api.request;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ImageUrlValidatorTest {
+    private ImageUrlValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ImageUrlValidator();
+    }
+
+    @Test
+    void validImageUrl_jpg_shouldReturnTrue() {
+        assertTrue(validator.isValid("https://dev-puzzle-api.nyangnyang.co.kr/images/original/test.jpg", null));
+    }
+
+    @Test
+    void validImageUrl_png_shouldReturnTrue() {
+        assertTrue(validator.isValid("https://dev-puzzle-api.nyangnyang.co.kr/images/original/test.png", null));
+    }
+
+    @Test
+    void invalidImageUrl_txt_shouldReturnFalse() {
+        assertFalse(validator.isValid("https://dev-puzzle-api.nyangnyang.co.kr/images/original/test.txt", null));
+    }
+
+    @Test
+    void invalidImageUrl_malformed_shouldReturnFalse() {
+        assertFalse(validator.isValid("not-a-url", null));
+    }
+
+    @Test
+    void nullImageUrl_shouldReturnFalse() {
+        assertFalse(validator.isValid(null, null));
+    }
+} 


### PR DESCRIPTION
### 티켓 번호
[KAN-16](https://nyangnyang.atlassian.net/browse/KAN-16?atlOrigin=eyJpIjoiODMwYTI0NGRmODNjNGY1YTgyMTRmZmZhYjVlMTE4MDkiLCJwIjoiaiJ9)

### PR 타입(하나 이상을 선택 후 나머지는 지워주세요)

- [x] 기능 추가 (새로운 기능을 추가할 때)

### 반영 브랜치

- `KAN-16-update-profile-image` -> `develop`

### 변경 사항

- Add `Update User Profile Image API`
- Add `Image Validator`

### 테스트 결과

<img width="316" alt="스크린샷 2025-06-04 오전 2 01 45" src="https://github.com/user-attachments/assets/5164482c-bb12-4b6f-835b-f98c424a2d3e" />


[KAN-16]: https://nyangnyang.atlassian.net/browse/KAN-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ